### PR TITLE
Reference geometry sketch tools

### DIFF
--- a/packages/app/src/editor/commands/index.ts
+++ b/packages/app/src/editor/commands/index.ts
@@ -29,6 +29,15 @@ export {
   // Offset Plane
   createOffsetPlane,
   type CreateOffsetPlaneArgs,
+  // Plane
+  createPlane,
+  type CreatePlaneArgs,
+  createMidplane,
+  type CreateMidplaneArgs,
+  create3PointPlane,
+  type Create3PointPlaneArgs,
+  createAnglePlane,
+  type CreateAnglePlaneArgs,
   // Axis
   createAxis,
   type CreateAxisArgs,

--- a/packages/app/src/editor/components/PropertiesPanel.css
+++ b/packages/app/src/editor/components/PropertiesPanel.css
@@ -549,6 +549,34 @@
   cursor: pointer;
 }
 
+/* Reference geometry selection rows */
+.reference-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.reference-pick {
+  padding: 2px 8px;
+  font-size: 11px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-bg);
+  color: var(--color-text);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.reference-pick:hover {
+  background: var(--color-bg-hover);
+}
+
+.reference-error {
+  margin: 8px;
+  font-size: 11px;
+  color: #e11d48;
+}
+
 .face-selector-btn:hover {
   background: var(--color-bg-hover);
 }

--- a/packages/app/src/editor/components/PropertiesPanel.tsx
+++ b/packages/app/src/editor/components/PropertiesPanel.tsx
@@ -12,7 +12,12 @@ import React, { useState, useCallback, useMemo } from "react";
 import { useDocument } from "../contexts/DocumentContext";
 import { useSelection } from "../contexts/SelectionContext";
 import { useFeatureEdit } from "../contexts/FeatureEditContext";
-import type { ExtrudeFormData, RevolveFormData } from "../types/featureSchemas";
+import type {
+  ExtrudeFormData,
+  RevolveFormData,
+  PlaneToolFormData,
+  AxisToolFormData,
+} from "../types/featureSchemas";
 import type { SketchLine } from "../types/document";
 import AIPanel from "./AIPanel";
 import { UserProfileDialog } from "../../components/dialogs/UserProfileDialog";
@@ -30,6 +35,8 @@ import {
   GenericProperties,
 } from "./properties-panel/feature-properties";
 import { ExtrudeEditForm, RevolveEditForm } from "./properties-panel/edit-forms";
+import { PlaneToolPanel } from "./tools/PlaneToolPanel";
+import { AxisToolPanel } from "./tools/AxisToolPanel";
 
 // ============================================================================
 // Main Component
@@ -114,6 +121,20 @@ const PropertiesPanel: React.FC = () => {
               axisCandidates={axisCandidates}
               onUpdate={updateFormData}
               onAccept={acceptEdit}
+              onCancel={cancelEdit}
+            />
+          )}
+          {editMode.type === "plane" && (
+            <PlaneToolPanel
+              data={editMode.data as PlaneToolFormData}
+              onUpdate={updateFormData}
+              onCancel={cancelEdit}
+            />
+          )}
+          {editMode.type === "axis" && (
+            <AxisToolPanel
+              data={editMode.data as AxisToolFormData}
+              onUpdate={updateFormData}
               onCancel={cancelEdit}
             />
           )}

--- a/packages/app/src/editor/components/StatusOverlay.css
+++ b/packages/app/src/editor/components/StatusOverlay.css
@@ -63,3 +63,20 @@
   font-size: 10px;
   color: var(--color-text-muted);
 }
+
+.status-sketch {
+  font-size: 11px;
+  color: var(--color-text-muted);
+}
+
+.status-sketch-full {
+  color: #22c55e;
+}
+
+.status-sketch-under {
+  color: #60a5fa;
+}
+
+.status-sketch-over {
+  color: #f87171;
+}

--- a/packages/app/src/editor/components/floating-toolbar/FeatureModeTools.tsx
+++ b/packages/app/src/editor/components/floating-toolbar/FeatureModeTools.tsx
@@ -23,10 +23,12 @@ export interface FeatureModeToolsProps {
 
   // Plane creation
   canCreatePlane: boolean;
-  onCreateOffsetPlane: () => void;
+  onCreatePlane: () => void;
   planeTooltip: string;
 
   // Axis creation
+  canCreateAxis: boolean;
+  onCreateAxis: () => void;
   onAddAxis: (definition: { kind: "datum"; role: "x" | "y" | "z" }) => void;
 
   // Extrude
@@ -57,8 +59,10 @@ export const FeatureModeTools: React.FC<FeatureModeToolsProps> = ({
   onNewSketch,
   sketchTooltip,
   canCreatePlane,
-  onCreateOffsetPlane,
+  onCreatePlane,
   planeTooltip,
+  onCreateAxis,
+  canCreateAxis,
   onAddAxis,
   canExtrude,
   onExtrude,
@@ -82,17 +86,20 @@ export const FeatureModeTools: React.FC<FeatureModeToolsProps> = ({
         />
         <ToolbarButton
           icon={<PlaneIcon />}
-          label="Add Offset Plane"
+          label="Plane"
           tooltip={planeTooltip}
-          onClick={onCreateOffsetPlane}
+          onClick={onCreatePlane}
           disabled={!canCreatePlane}
         />
 
         {/* Axis Creation Dropdown */}
         <Menu.Root>
           <Menu.Trigger
-            className="floating-toolbar-button floating-toolbar-dropdown-button"
+            className={`floating-toolbar-button floating-toolbar-dropdown-button ${
+              !canCreateAxis ? "disabled" : ""
+            }`}
             aria-label="Add Axis"
+            disabled={!canCreateAxis}
           >
             <AxisIcon />
             <ChevronDownIcon />
@@ -102,19 +109,30 @@ export const FeatureModeTools: React.FC<FeatureModeToolsProps> = ({
               <Menu.Popup className="floating-toolbar-dropdown-menu">
                 <Menu.Item
                   className="floating-toolbar-dropdown-item"
+                  onClick={onCreateAxis}
+                  disabled={!canCreateAxis}
+                >
+                  Axis Tool...
+                </Menu.Item>
+                <Menu.Separator className="floating-toolbar-dropdown-separator" />
+                <Menu.Item
+                  className="floating-toolbar-dropdown-item"
                   onClick={() => onAddAxis({ kind: "datum", role: "x" })}
+                  disabled={!canCreateAxis}
                 >
                   X Axis (datum)
                 </Menu.Item>
                 <Menu.Item
                   className="floating-toolbar-dropdown-item"
                   onClick={() => onAddAxis({ kind: "datum", role: "y" })}
+                  disabled={!canCreateAxis}
                 >
                   Y Axis (datum)
                 </Menu.Item>
                 <Menu.Item
                   className="floating-toolbar-dropdown-item"
                   onClick={() => onAddAxis({ kind: "datum", role: "z" })}
+                  disabled={!canCreateAxis}
                 >
                   Z Axis (datum)
                 </Menu.Item>

--- a/packages/app/src/editor/components/floating-toolbar/SketchModeTools.tsx
+++ b/packages/app/src/editor/components/floating-toolbar/SketchModeTools.tsx
@@ -89,6 +89,14 @@ export const SketchModeTools: React.FC<SketchModeToolsProps> = ({
     activeTool === "rectangle" ||
     activeTool === "rectangleCenter" ||
     activeTool === "rectangle3Point";
+  const isModifyActive = [
+    "trim",
+    "extend",
+    "offset",
+    "mirror",
+    "fillet",
+    "chamfer",
+  ].includes(activeTool);
 
   return (
     <div className="floating-toolbar-group">
@@ -276,6 +284,57 @@ export const SketchModeTools: React.FC<SketchModeToolsProps> = ({
                   onClick={() => setTool("rectangle3Point")}
                 >
                   3-Point Rectangle (Edge + Width, any angle)
+                </Menu.Item>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>
+      </div>
+
+      {/* Modify Tools Menu */}
+      <div className="floating-toolbar-button-group">
+        <Tooltip.Root>
+          <Tooltip.Trigger
+            delay={300}
+            className={`floating-toolbar-button ${isModifyActive ? "active" : ""}`}
+            onClick={() => toggleTool("trim")}
+            render={<button aria-label="Modify tools" />}
+          >
+            <OptionsIcon />
+          </Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Positioner side="top" sideOffset={6}>
+              <Tooltip.Popup className="floating-toolbar-tooltip">Modify</Tooltip.Popup>
+            </Tooltip.Positioner>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+        <Menu.Root>
+          <Menu.Trigger
+            className="floating-toolbar-flyout-trigger"
+            render={<button aria-label="Modify options" />}
+          >
+            <ChevronDownIcon />
+          </Menu.Trigger>
+          <Menu.Portal>
+            <Menu.Positioner sideOffset={4}>
+              <Menu.Popup className="floating-toolbar-menu">
+                <Menu.Item className="floating-toolbar-menu-item" onClick={() => setTool("trim")}>
+                  Trim
+                </Menu.Item>
+                <Menu.Item className="floating-toolbar-menu-item" onClick={() => setTool("extend")}>
+                  Extend
+                </Menu.Item>
+                <Menu.Item className="floating-toolbar-menu-item" onClick={() => setTool("offset")}>
+                  Offset
+                </Menu.Item>
+                <Menu.Item className="floating-toolbar-menu-item" onClick={() => setTool("mirror")}>
+                  Mirror
+                </Menu.Item>
+                <Menu.Item className="floating-toolbar-menu-item" onClick={() => setTool("fillet")}>
+                  Fillet
+                </Menu.Item>
+                <Menu.Item className="floating-toolbar-menu-item" onClick={() => setTool("chamfer")}>
+                  Chamfer
                 </Menu.Item>
               </Menu.Popup>
             </Menu.Positioner>

--- a/packages/app/src/editor/components/properties-panel/feature-properties/AxisProperties.tsx
+++ b/packages/app/src/editor/components/properties-panel/feature-properties/AxisProperties.tsx
@@ -38,6 +38,11 @@ export function AxisProperties({ feature, onUpdate }: FeaturePropertiesProps) {
           type: "Two Points",
           details: null,
         };
+      case "twoPlanes":
+        return {
+          type: "Two Planes",
+          details: `Planes: ${definition.plane1Ref} / ${definition.plane2Ref}`,
+        };
       case "sketchLine":
         return {
           type: "Sketch Line",

--- a/packages/app/src/editor/components/properties-panel/feature-properties/PlaneProperties.tsx
+++ b/packages/app/src/editor/components/properties-panel/feature-properties/PlaneProperties.tsx
@@ -56,6 +56,11 @@ export function PlaneProperties({ feature, onUpdate }: FeaturePropertiesProps) {
           details: `Face: ${definition.faceRef}`,
           distance: definition.distance as number,
         };
+      case "midplane":
+        return {
+          type: "Midplane",
+          details: `Between: ${definition.plane1Ref} / ${definition.plane2Ref}`,
+        };
       case "onFace":
         return {
           type: "On Face",

--- a/packages/app/src/editor/components/tools/AxisToolPanel.tsx
+++ b/packages/app/src/editor/components/tools/AxisToolPanel.tsx
@@ -1,0 +1,267 @@
+import { useMemo, useState } from "react";
+import { useDocument } from "../../contexts/DocumentContext";
+import { useKernel } from "../../contexts/KernelContext";
+import { useSelection } from "../../contexts/SelectionContext";
+import type { AxisToolFormData } from "../../types/featureSchemas";
+import {
+  PropertyGroup,
+  PropertyRow,
+  TextInput,
+  NumberInput,
+  SelectInput,
+} from "../properties-panel/inputs";
+import {
+  computeAxisFromEdgeMesh,
+  computeAxisFromTwoPlanes,
+  computeAxisFromTwoPoints,
+  computePlaneFromFaceMesh,
+  computeOrthonormalBasis,
+  cross,
+  normalize,
+  parseEdgeRef,
+  parseFaceRef,
+  parsePointRef,
+  type PlaneBasis,
+  type AxisLine,
+} from "../../lib/reference-geometry";
+import { findDatumPlaneByRole } from "../../document/createDocument";
+
+export interface AxisToolPanelProps {
+  data: AxisToolFormData;
+  onUpdate: (update: Partial<AxisToolFormData>) => void;
+  onCancel: () => void;
+}
+
+const modeOptions = [
+  { value: "auto", label: "Auto-detect" },
+  { value: "linear", label: "Linear entity" },
+  { value: "twoPoints", label: "Two points" },
+  { value: "twoPlanes", label: "Two planes" },
+] as const;
+
+export function AxisToolPanel({ data, onUpdate, onCancel }: AxisToolPanelProps) {
+  const { getFeatureById, addAxis, doc } = useDocument();
+  const { meshes } = useKernel();
+  const { selectedEdges, selectedFaces, selectedFeatureId } = useSelection();
+  const [error, setError] = useState<string | null>(null);
+
+  const effectiveMode = useMemo(() => {
+    if (data.mode !== "auto") return data.mode;
+    if (data.ref1 && data.ref2) {
+      if (data.ref1.startsWith("point:") && data.ref2.startsWith("point:")) {
+        return "twoPoints";
+      }
+      return "twoPlanes";
+    }
+    if (data.ref1) return "linear";
+    return "linear";
+  }, [data.mode, data.ref1, data.ref2]);
+
+  const getSelectedPlaneRef = (): string | null => {
+    if (!doc) return null;
+    const feature = selectedFeatureId ? getFeatureById(selectedFeatureId) : null;
+    if (feature?.type === "plane") return feature.id;
+    if (selectedFaces.length === 1) {
+      const face = selectedFaces[0];
+      return `face:${face.featureId}:${face.faceIndex}`;
+    }
+    return null;
+  };
+
+  const getSelectedEdgeRef = (): string | null => {
+    if (selectedEdges.length !== 1) return null;
+    const edge = selectedEdges[0];
+    return `edge:${edge.featureId}:${edge.edgeIndex}`;
+  };
+
+  const resolvePlaneBasis = (ref?: string): PlaneBasis | null => {
+    if (!ref) return null;
+    const face = parseFaceRef(ref);
+    if (face) {
+      const mesh = meshes.get(face.featureId);
+      if (!mesh) return null;
+      return computePlaneFromFaceMesh(mesh, face.faceIndex);
+    }
+    if (ref === "xy" || ref === "xz" || ref === "yz") {
+      if (!doc) return null;
+      const planeId = findDatumPlaneByRole(doc, ref);
+      if (!planeId) return null;
+      ref = planeId;
+    }
+    const feature = getFeatureById(ref);
+    if (feature?.type === "plane") {
+      const normal = feature.normal;
+      const basis = computeOrthonormalBasis(normal);
+      const xDir = feature.xDir ?? basis.xDir;
+      const yDir = normalize(cross(normal, xDir));
+      return { origin: feature.origin, normal, xDir, yDir };
+    }
+    return null;
+  };
+
+  const resolveAxis = (ref?: string): AxisLine | null => {
+    if (!ref) return null;
+    const edge = parseEdgeRef(ref);
+    if (edge) {
+      const mesh = meshes.get(edge.featureId);
+      if (!mesh) return null;
+      return computeAxisFromEdgeMesh(mesh, edge.edgeIndex);
+    }
+    const feature = getFeatureById(ref);
+    if (feature?.type === "axis") {
+      return { origin: feature.origin, direction: feature.direction };
+    }
+    return null;
+  };
+
+  const handleUseSelection = (slot: "ref1" | "ref2") => {
+    if (effectiveMode === "linear") {
+      const edgeRef = getSelectedEdgeRef();
+      if (edgeRef && slot === "ref1") onUpdate({ ref1: edgeRef });
+      return;
+    }
+
+    const planeRef = getSelectedPlaneRef();
+    if (planeRef) onUpdate({ [slot]: planeRef } as Partial<AxisToolFormData>);
+  };
+
+  const handleAccept = () => {
+    setError(null);
+    const mode = effectiveMode;
+
+    if (mode === "twoPoints") {
+      const p1 = parsePointRef(data.ref1 ?? "");
+      const p2 = parsePointRef(data.ref2 ?? "");
+      if (!p1 || !p2) {
+        setError("Provide two valid point coordinates.");
+        return;
+      }
+      const axis = computeAxisFromTwoPoints(p1, p2);
+      if (!axis) {
+        setError("Points are identical - cannot create axis.");
+        return;
+      }
+      addAxis({
+        name: data.name,
+        definition: { kind: "twoPoints", point1Ref: data.ref1 ?? "", point2Ref: data.ref2 ?? "" },
+        origin: axis.origin,
+        direction: axis.direction,
+        length: data.length,
+      });
+      onCancel();
+      return;
+    }
+
+    if (mode === "twoPlanes") {
+      const p1 = resolvePlaneBasis(data.ref1);
+      const p2 = resolvePlaneBasis(data.ref2);
+      if (!p1 || !p2) {
+        setError("Select two planar references.");
+        return;
+      }
+      const axis = computeAxisFromTwoPlanes(p1, p2);
+      if (!axis) {
+        setError("Planes are parallel - no intersection axis.");
+        return;
+      }
+      addAxis({
+        name: data.name,
+        definition: { kind: "twoPlanes", plane1Ref: data.ref1 ?? "", plane2Ref: data.ref2 ?? "" },
+        origin: axis.origin,
+        direction: axis.direction,
+        length: data.length,
+      });
+      onCancel();
+      return;
+    }
+
+    const axis = resolveAxis(data.ref1);
+    if (!axis) {
+      setError("Select a linear reference for the axis.");
+      return;
+    }
+    if (!data.ref1?.startsWith("edge:")) {
+      setError("Linear axis requires an edge reference (edge:featureId:edgeIndex).");
+      return;
+    }
+    addAxis({
+      name: data.name,
+      definition: { kind: "edge", edgeRef: data.ref1 },
+      origin: axis.origin,
+      direction: axis.direction,
+      length: data.length,
+    });
+    onCancel();
+  };
+
+  return (
+    <PropertyGroup>
+      <PropertyRow label="Name">
+        <TextInput value={data.name} onChange={(name) => onUpdate({ name })} />
+      </PropertyRow>
+      <PropertyRow label="Type">
+        <SelectInput
+          value={data.mode}
+          onChange={(mode) => onUpdate({ mode })}
+          options={modeOptions}
+        />
+      </PropertyRow>
+
+      {(effectiveMode === "linear" || effectiveMode === "twoPlanes") && (
+        <PropertyRow label="Reference 1">
+          <div className="reference-row">
+            <TextInput value={data.ref1 ?? ""} onChange={(ref1) => onUpdate({ ref1 })} />
+            <button className="reference-pick" onClick={() => handleUseSelection("ref1")}>
+              Use Selection
+            </button>
+          </div>
+        </PropertyRow>
+      )}
+
+      {effectiveMode === "twoPlanes" && (
+        <PropertyRow label="Reference 2">
+          <div className="reference-row">
+            <TextInput value={data.ref2 ?? ""} onChange={(ref2) => onUpdate({ ref2 })} />
+            <button className="reference-pick" onClick={() => handleUseSelection("ref2")}>
+              Use Selection
+            </button>
+          </div>
+        </PropertyRow>
+      )}
+
+      {effectiveMode === "twoPoints" && (
+        <>
+          <PropertyRow label="Point 1">
+            <TextInput
+              value={data.ref1 ?? ""}
+              onChange={(ref1) => onUpdate({ ref1 })}
+              placeholder="point:x,y,z"
+            />
+          </PropertyRow>
+          <PropertyRow label="Point 2">
+            <TextInput
+              value={data.ref2 ?? ""}
+              onChange={(ref2) => onUpdate({ ref2 })}
+              placeholder="point:x,y,z"
+            />
+          </PropertyRow>
+        </>
+      )}
+
+      <PropertyRow label="Length">
+        <NumberInput value={data.length} onChange={(length) => onUpdate({ length })} unit="mm" />
+      </PropertyRow>
+
+      {error && <div className="reference-error">{error}</div>}
+
+      <div className="properties-panel-actions">
+        <button className="properties-btn properties-btn-cancel" onClick={onCancel}>
+          Cancel
+        </button>
+        <button className="properties-btn properties-btn-accept" onClick={handleAccept}>
+          OK
+        </button>
+      </div>
+    </PropertyGroup>
+  );
+}

--- a/packages/app/src/editor/components/tools/PlaneToolPanel.tsx
+++ b/packages/app/src/editor/components/tools/PlaneToolPanel.tsx
@@ -1,0 +1,359 @@
+import { useMemo, useState } from "react";
+import { useDocument } from "../../contexts/DocumentContext";
+import { useKernel } from "../../contexts/KernelContext";
+import { useSelection } from "../../contexts/SelectionContext";
+import type { PlaneToolFormData } from "../../types/featureSchemas";
+import {
+  PropertyGroup,
+  PropertyRow,
+  TextInput,
+  NumberInput,
+  SelectInput,
+  CheckboxInput,
+} from "../properties-panel/inputs";
+import {
+  computeAnglePlane,
+  computeMidplane,
+  computePlaneFromFaceMesh,
+  computePlaneFromPoints,
+  computeAxisFromEdgeMesh,
+  computeOrthonormalBasis,
+  cross,
+  normalize,
+  parseFaceRef,
+  parseEdgeRef,
+  parsePointRef,
+  type PlaneBasis,
+  type AxisLine,
+} from "../../lib/reference-geometry";
+import { findDatumPlaneByRole } from "../../document/createDocument";
+
+export interface PlaneToolPanelProps {
+  data: PlaneToolFormData;
+  onUpdate: (update: Partial<PlaneToolFormData>) => void;
+  onCancel: () => void;
+}
+
+const modeOptions = [
+  { value: "auto", label: "Auto-detect" },
+  { value: "offset", label: "Offset" },
+  { value: "midplane", label: "Midplane" },
+  { value: "angle", label: "Angle" },
+  { value: "threePoint", label: "3-Point" },
+] as const;
+
+export function PlaneToolPanel({ data, onUpdate, onCancel }: PlaneToolPanelProps) {
+  const { getFeatureById, addPlane, doc } = useDocument();
+  const { meshes } = useKernel();
+  const { selectedFaces, selectedEdges, selectedFeatureId } = useSelection();
+  const [error, setError] = useState<string | null>(null);
+
+  const effectiveMode = useMemo(() => {
+    if (data.mode !== "auto") return data.mode;
+    if (data.ref1 && data.ref2 && data.ref3) return "threePoint";
+    if (data.ref1 && data.ref2) {
+      if (data.ref2.startsWith("edge:")) return "angle";
+      return "midplane";
+    }
+    return "offset";
+  }, [data.mode, data.ref1, data.ref2, data.ref3]);
+
+  const getSelectedPlaneRef = (): string | null => {
+    if (!doc) return null;
+    const feature = selectedFeatureId ? getFeatureById(selectedFeatureId) : null;
+    if (feature?.type === "plane") return feature.id;
+    if (selectedFaces.length === 1) {
+      const face = selectedFaces[0];
+      return `face:${face.featureId}:${face.faceIndex}`;
+    }
+    return null;
+  };
+
+  const getSelectedEdgeRef = (): string | null => {
+    if (selectedEdges.length !== 1) return null;
+    const edge = selectedEdges[0];
+    return `edge:${edge.featureId}:${edge.edgeIndex}`;
+  };
+
+  const resolvePlaneBasis = (ref?: string): PlaneBasis | null => {
+    if (!ref) return null;
+    const face = parseFaceRef(ref);
+    if (face) {
+      const mesh = meshes.get(face.featureId);
+      if (!mesh) return null;
+      return computePlaneFromFaceMesh(mesh, face.faceIndex);
+    }
+
+    if (ref === "xy" || ref === "xz" || ref === "yz") {
+      if (!doc) return null;
+      const planeId = findDatumPlaneByRole(doc, ref);
+      if (!planeId) return null;
+      ref = planeId;
+    }
+
+    const feature = getFeatureById(ref);
+    if (feature?.type === "plane") {
+      const normal = feature.normal;
+      const basis = computeOrthonormalBasis(normal);
+      const xDir = feature.xDir ?? basis.xDir;
+      const yDir = normalize(cross(normal, xDir));
+      return { origin: feature.origin, normal, xDir, yDir };
+    }
+    return null;
+  };
+
+  const resolveAxis = (ref?: string): AxisLine | null => {
+    if (!ref) return null;
+    const edge = parseEdgeRef(ref);
+    if (edge) {
+      const mesh = meshes.get(edge.featureId);
+      if (!mesh) return null;
+      return computeAxisFromEdgeMesh(mesh, edge.edgeIndex);
+    }
+
+    const feature = getFeatureById(ref);
+    if (feature?.type === "axis") {
+      return { origin: feature.origin, direction: feature.direction };
+    }
+    return null;
+  };
+
+  const handleUseSelection = (slot: "ref1" | "ref2") => {
+    if (effectiveMode === "angle" && slot === "ref2") {
+      const edgeRef = getSelectedEdgeRef();
+      if (edgeRef) onUpdate({ ref2: edgeRef });
+      return;
+    }
+
+    const planeRef = getSelectedPlaneRef();
+    if (planeRef) {
+      onUpdate({ [slot]: planeRef } as Partial<PlaneToolFormData>);
+    }
+  };
+
+  const handleAccept = () => {
+    setError(null);
+    const mode = effectiveMode;
+
+    if (mode === "threePoint") {
+      const p1 = parsePointRef(data.ref1 ?? "");
+      const p2 = parsePointRef(data.ref2 ?? "");
+      const p3 = parsePointRef(data.ref3 ?? "");
+      if (!p1 || !p2 || !p3) {
+        setError("Provide three valid point coordinates.");
+        return;
+      }
+      const plane = computePlaneFromPoints(p1, p2, p3);
+      if (!plane) {
+        setError("Points are collinear - cannot create plane.");
+        return;
+      }
+      const normal = data.flipNormal ? [-plane.normal[0], -plane.normal[1], -plane.normal[2]] : plane.normal;
+      const xDir = data.flipNormal ? [-plane.xDir[0], -plane.xDir[1], -plane.xDir[2]] : plane.xDir;
+      addPlane({
+        name: data.name,
+        definition: {
+          kind: "threePoints",
+          point1Ref: data.ref1 ?? "",
+          point2Ref: data.ref2 ?? "",
+          point3Ref: data.ref3 ?? "",
+        },
+        origin: plane.origin,
+        normal,
+        xDir,
+        width: data.width,
+        height: data.height,
+      });
+      onCancel();
+      return;
+    }
+
+    if (mode === "offset") {
+      const base = resolvePlaneBasis(data.ref1);
+      if (!base) {
+        setError("Select a planar face or plane for Reference 1.");
+        return;
+      }
+      const offset = data.flipNormal ? -data.offset : data.offset;
+      const origin = [
+        base.origin[0] + base.normal[0] * offset,
+        base.origin[1] + base.normal[1] * offset,
+        base.origin[2] + base.normal[2] * offset,
+      ] as [number, number, number];
+
+      const definition = data.ref1?.startsWith("face:")
+        ? { kind: "offsetFace", faceRef: data.ref1, distance: data.offset }
+        : { kind: "offsetPlane", basePlaneId: data.ref1 ?? "", distance: data.offset };
+
+      addPlane({
+        name: data.name,
+        definition,
+        origin,
+        normal: base.normal,
+        xDir: base.xDir,
+        width: data.width,
+        height: data.height,
+      });
+      onCancel();
+      return;
+    }
+
+    if (mode === "midplane") {
+      const p1 = resolvePlaneBasis(data.ref1);
+      const p2 = resolvePlaneBasis(data.ref2);
+      if (!p1 || !p2) {
+        setError("Select two planar references for midplane.");
+        return;
+      }
+      const plane = computeMidplane(p1, p2);
+      if (!plane) {
+        setError("Selected planes are not parallel.");
+        return;
+      }
+      const normal = data.flipNormal ? [-plane.normal[0], -plane.normal[1], -plane.normal[2]] : plane.normal;
+      const xDir = data.flipNormal ? [-plane.xDir[0], -plane.xDir[1], -plane.xDir[2]] : plane.xDir;
+      addPlane({
+        name: data.name,
+        definition: {
+          kind: "midplane",
+          plane1Ref: data.ref1 ?? "",
+          plane2Ref: data.ref2 ?? "",
+        },
+        origin: plane.origin,
+        normal,
+        xDir,
+        width: data.width,
+        height: data.height,
+      });
+      onCancel();
+      return;
+    }
+
+    if (mode === "angle") {
+      const basePlane = resolvePlaneBasis(data.ref1);
+      const axis = resolveAxis(data.ref2);
+      if (!basePlane || !axis) {
+        setError("Select a plane and a linear reference for angle.");
+        return;
+      }
+      const plane = computeAnglePlane(basePlane, axis, data.angle);
+      const normal = data.flipNormal ? [-plane.normal[0], -plane.normal[1], -plane.normal[2]] : plane.normal;
+      const xDir = data.flipNormal ? [-plane.xDir[0], -plane.xDir[1], -plane.xDir[2]] : plane.xDir;
+      addPlane({
+        name: data.name,
+        definition: {
+          kind: "axisAngle",
+          axisRef: data.ref2 ?? "",
+          angle: data.angle,
+          basePlaneRef: data.ref1 ?? "",
+        },
+        origin: plane.origin,
+        normal,
+        xDir,
+        width: data.width,
+        height: data.height,
+      });
+      onCancel();
+    }
+  };
+
+  return (
+    <PropertyGroup>
+      <PropertyRow label="Name">
+        <TextInput value={data.name} onChange={(name) => onUpdate({ name })} />
+      </PropertyRow>
+      <PropertyRow label="Type">
+        <SelectInput
+          value={data.mode}
+          onChange={(mode) => onUpdate({ mode })}
+          options={modeOptions}
+        />
+      </PropertyRow>
+
+      {(effectiveMode === "offset" || effectiveMode === "midplane" || effectiveMode === "angle") && (
+        <PropertyRow label="Reference 1">
+          <div className="reference-row">
+            <TextInput value={data.ref1 ?? ""} onChange={(ref1) => onUpdate({ ref1 })} />
+            <button className="reference-pick" onClick={() => handleUseSelection("ref1")}>
+              Use Selection
+            </button>
+          </div>
+        </PropertyRow>
+      )}
+
+      {(effectiveMode === "midplane" || effectiveMode === "angle") && (
+        <PropertyRow label="Reference 2">
+          <div className="reference-row">
+            <TextInput value={data.ref2 ?? ""} onChange={(ref2) => onUpdate({ ref2 })} />
+            <button className="reference-pick" onClick={() => handleUseSelection("ref2")}>
+              Use Selection
+            </button>
+          </div>
+        </PropertyRow>
+      )}
+
+      {effectiveMode === "threePoint" && (
+        <>
+          <PropertyRow label="Point 1">
+            <TextInput
+              value={data.ref1 ?? ""}
+              onChange={(ref1) => onUpdate({ ref1 })}
+              placeholder="point:x,y,z"
+            />
+          </PropertyRow>
+          <PropertyRow label="Point 2">
+            <TextInput
+              value={data.ref2 ?? ""}
+              onChange={(ref2) => onUpdate({ ref2 })}
+              placeholder="point:x,y,z"
+            />
+          </PropertyRow>
+          <PropertyRow label="Point 3">
+            <TextInput
+              value={data.ref3 ?? ""}
+              onChange={(ref3) => onUpdate({ ref3 })}
+              placeholder="point:x,y,z"
+            />
+          </PropertyRow>
+        </>
+      )}
+
+      {effectiveMode === "offset" && (
+        <PropertyRow label="Offset">
+          <NumberInput value={data.offset} onChange={(offset) => onUpdate({ offset })} unit="mm" />
+        </PropertyRow>
+      )}
+
+      {effectiveMode === "angle" && (
+        <PropertyRow label="Angle">
+          <NumberInput value={data.angle} onChange={(angle) => onUpdate({ angle })} unit="°" />
+        </PropertyRow>
+      )}
+
+      <PropertyRow label="Flip Normal">
+        <CheckboxInput
+          checked={data.flipNormal}
+          onChange={(flipNormal) => onUpdate({ flipNormal })}
+        />
+      </PropertyRow>
+
+      <PropertyRow label="Width">
+        <NumberInput value={data.width} onChange={(width) => onUpdate({ width })} unit="mm" />
+      </PropertyRow>
+      <PropertyRow label="Height">
+        <NumberInput value={data.height} onChange={(height) => onUpdate({ height })} unit="mm" />
+      </PropertyRow>
+
+      {error && <div className="reference-error">{error}</div>}
+
+      <div className="properties-panel-actions">
+        <button className="properties-btn properties-btn-cancel" onClick={onCancel}>
+          Cancel
+        </button>
+        <button className="properties-btn properties-btn-accept" onClick={handleAccept}>
+          OK
+        </button>
+      </div>
+    </PropertyGroup>
+  );
+}

--- a/packages/app/src/editor/components/viewer/Viewer.tsx
+++ b/packages/app/src/editor/components/viewer/Viewer.tsx
@@ -443,6 +443,7 @@ const Viewer: React.FC = () => {
     addAngledRectangle,
     addConstraint: addConstraintWrapper,
     updatePointPosition,
+    selectedLines,
     setSelectedPoints,
     setSelectedLines,
     setSelectedConstraints,

--- a/packages/app/src/editor/contexts/DocumentContext.tsx
+++ b/packages/app/src/editor/contexts/DocumentContext.tsx
@@ -25,12 +25,13 @@ import {
   addRevolveFeature,
   addBooleanFeature,
   addOffsetPlane as addOffsetPlaneFeature,
+  addPlaneFeature,
   addAxisFeature,
   deleteFeature,
   renameFeature,
   toggleFeatureVisibility,
 } from "../document/featureHelpers";
-import type { AxisFeatureOptions } from "../document/featureHelpers";
+import type { AxisFeatureOptions, PlaneFeatureOptions } from "../document/featureHelpers";
 import type { Feature } from "../document/schema";
 import { createDocumentSync, type DocumentSync } from "../../lib/yjs-sync";
 import { SolidTypeAwareness } from "../../lib/awareness-provider";
@@ -81,6 +82,8 @@ interface DocumentContextValue {
   ) => string;
   /** Add an offset plane from a datum plane or face */
   addOffsetPlane: (basePlaneId: string, offset: number, name?: string) => string;
+  /** Add a plane from a definition */
+  addPlane: (options: PlaneFeatureOptions) => string;
   /** Add an axis feature */
   addAxis: (options: AxisFeatureOptions) => string;
   getFeatureById: (id: string) => Feature | null;
@@ -498,6 +501,14 @@ export function DocumentProvider({ children, documentId }: DocumentProviderProps
     [doc]
   );
 
+  const addPlane = useCallback(
+    (options: PlaneFeatureOptions) => {
+      if (!doc) return "";
+      return addPlaneFeature(doc, options);
+    },
+    [doc]
+  );
+
   const addAxis = useCallback(
     (options: AxisFeatureOptions) => {
       if (!doc) return "";
@@ -565,6 +576,7 @@ export function DocumentProvider({ children, documentId }: DocumentProviderProps
     addRevolve,
     addBoolean,
     addOffsetPlane,
+    addPlane,
     addAxis,
     getFeatureById,
     deleteFeature: handleDeleteFeature,

--- a/packages/app/src/editor/contexts/FeatureEditContext.tsx
+++ b/packages/app/src/editor/contexts/FeatureEditContext.tsx
@@ -8,7 +8,12 @@
 import React, { createContext, useContext, useState, useCallback, useRef } from "react";
 import { useDocument } from "./DocumentContext";
 import { useKernel } from "./KernelContext";
-import type { ExtrudeFormData, RevolveFormData } from "../types/featureSchemas";
+import type {
+  ExtrudeFormData,
+  RevolveFormData,
+  PlaneToolFormData,
+  AxisToolFormData,
+} from "../types/featureSchemas";
 
 // ============================================================================
 // Types
@@ -17,7 +22,9 @@ import type { ExtrudeFormData, RevolveFormData } from "../types/featureSchemas";
 export type FeatureEditMode =
   | { type: "none" }
   | { type: "extrude"; sketchId: string; data: ExtrudeFormData }
-  | { type: "revolve"; sketchId: string; data: RevolveFormData };
+  | { type: "revolve"; sketchId: string; data: RevolveFormData }
+  | { type: "plane"; data: PlaneToolFormData }
+  | { type: "axis"; data: AxisToolFormData };
 
 interface FeatureEditContextValue {
   editMode: FeatureEditMode;
@@ -28,8 +35,20 @@ interface FeatureEditContextValue {
   /** Start creating a new revolve feature */
   startRevolveEdit: (sketchId: string) => void;
 
+  /** Start creating a new reference plane */
+  startPlaneEdit: (data: PlaneToolFormData) => void;
+
+  /** Start creating a new reference axis */
+  startAxisEdit: (data: AxisToolFormData) => void;
+
   /** Update the form data while editing */
-  updateFormData: (data: Partial<ExtrudeFormData> | Partial<RevolveFormData>) => void;
+  updateFormData: (
+    data:
+      | Partial<ExtrudeFormData>
+      | Partial<RevolveFormData>
+      | Partial<PlaneToolFormData>
+      | Partial<AxisToolFormData>
+  ) => void;
 
   /** Accept the current edit and create the feature */
   acceptEdit: () => void;
@@ -162,6 +181,14 @@ export function FeatureEditProvider({ children }: FeatureEditProviderProps) {
     [getFeatureById, getNextName, schedulePreview]
   );
 
+  const startPlaneEdit = useCallback((data: PlaneToolFormData) => {
+    setEditMode({ type: "plane", data });
+  }, []);
+
+  const startAxisEdit = useCallback((data: AxisToolFormData) => {
+    setEditMode({ type: "axis", data });
+  }, []);
+
   const updateFormData = useCallback(
     (data: Partial<ExtrudeFormData> | Partial<RevolveFormData>) => {
       setEditMode((prev) => {
@@ -186,7 +213,7 @@ export function FeatureEditProvider({ children }: FeatureEditProviderProps) {
       previewTimerRef.current = null;
     }
 
-    if (editMode.type === "extrude") {
+      if (editMode.type === "extrude") {
       const { data, sketchId } = editMode;
       addExtrude(sketchId, data.distance ?? 10, data.op, data.direction);
     } else if (editMode.type === "revolve") {
@@ -213,6 +240,8 @@ export function FeatureEditProvider({ children }: FeatureEditProviderProps) {
     editMode,
     startExtrudeEdit,
     startRevolveEdit,
+    startPlaneEdit,
+    startAxisEdit,
     updateFormData,
     acceptEdit,
     cancelEdit,

--- a/packages/app/src/editor/document/feature-helpers/sketch-data.ts
+++ b/packages/app/src/editor/document/feature-helpers/sketch-data.ts
@@ -259,6 +259,9 @@ export function addConstraintToSketch(
   if ("arc" in constraint) {
     constraintMap.set("arc", constraint.arc);
   }
+  if ("arcs" in constraint) {
+    constraintMap.set("arcs", constraint.arcs);
+  }
   if ("connectionPoint" in constraint) {
     constraintMap.set("connectionPoint", constraint.connectionPoint);
   }
@@ -363,6 +366,12 @@ export function setSketchData(
       entityMap.set("end", entity.end);
       entityMap.set("center", entity.center);
       entityMap.set("ccw", entity.ccw);
+    } else if (entity.type === "circle") {
+      entityMap.set("center", entity.center);
+      entityMap.set("radius", entity.radius);
+    }
+    if (entity.construction !== undefined) {
+      entityMap.set("construction", entity.construction);
     }
   }
 

--- a/packages/app/src/editor/document/schema.ts
+++ b/packages/app/src/editor/document/schema.ts
@@ -212,12 +212,37 @@ export const TangentConstraintSchema = z
   })
   .strict();
 
+export const EqualRadiusConstraintSchema = z
+  .object({
+    id: UUID,
+    type: z.literal("equalRadius"),
+    arcs: z.tuple([UUID, UUID]),
+  })
+  .strict();
+
+export const ConcentricConstraintSchema = z
+  .object({
+    id: UUID,
+    type: z.literal("concentric"),
+    arcs: z.tuple([UUID, UUID]),
+  })
+  .strict();
+
 export const SymmetricConstraintSchema = z
   .object({
     id: UUID,
     type: z.literal("symmetric"),
     points: z.tuple([UUID, UUID]),
     axis: UUID,
+  })
+  .strict();
+
+export const MidpointConstraintSchema = z
+  .object({
+    id: UUID,
+    type: z.literal("midpoint"),
+    point: UUID,
+    line: UUID,
   })
   .strict();
 
@@ -251,7 +276,10 @@ export const SketchConstraintSchema = z.union([
   PerpendicularConstraintSchema,
   EqualLengthConstraintSchema,
   TangentConstraintSchema,
+  EqualRadiusConstraintSchema,
+  ConcentricConstraintSchema,
   SymmetricConstraintSchema,
+  MidpointConstraintSchema,
   PointOnLineConstraintSchema,
   PointOnArcConstraintSchema,
 ]);
@@ -312,6 +340,17 @@ export const OffsetPlaneDefinitionSchema = z
     basePlaneId: z.string(),
     /** Offset distance in mm (positive = along normal, negative = opposite) */
     distance: z.number(),
+  })
+  .strict();
+
+/** Midplane between two planes/faces */
+export const MidplaneDefinitionSchema = z
+  .object({
+    kind: z.literal("midplane"),
+    /** Reference to first plane/face */
+    plane1Ref: z.string(),
+    /** Reference to second plane/face */
+    plane2Ref: z.string(),
   })
   .strict();
 
@@ -398,6 +437,7 @@ export const SketchLinePointDefinitionSchema = z
 export const PlaneDefinitionSchema = z.discriminatedUnion("kind", [
   DatumPlaneDefinitionSchema,
   OffsetPlaneDefinitionSchema,
+  MidplaneDefinitionSchema,
   OffsetFaceDefinitionSchema,
   OnFaceDefinitionSchema,
   ThreePointsDefinitionSchema,
@@ -444,6 +484,15 @@ export const TwoPointsAxisDefinitionSchema = z
   })
   .strict();
 
+/** Intersection of two planes */
+export const TwoPlanesAxisDefinitionSchema = z
+  .object({
+    kind: z.literal("twoPlanes"),
+    plane1Ref: z.string(),
+    plane2Ref: z.string(),
+  })
+  .strict();
+
 /** Along a sketch line */
 export const SketchLineAxisDefinitionSchema = z
   .object({
@@ -469,6 +518,7 @@ export const AxisDefinitionSchema = z.discriminatedUnion("kind", [
   DatumAxisDefinitionSchema,
   SurfaceNormalDefinitionSchema,
   TwoPointsAxisDefinitionSchema,
+  TwoPlanesAxisDefinitionSchema,
   SketchLineAxisDefinitionSchema,
   EdgeAxisDefinitionSchema,
 ]);

--- a/packages/app/src/editor/kernel/KernelEngine.ts
+++ b/packages/app/src/editor/kernel/KernelEngine.ts
@@ -37,6 +37,9 @@ import {
   perpendicular,
   equalLength,
   tangent,
+  equalRadius,
+  concentric,
+  midpoint,
   symmetric,
   pointOnLine,
   pointOnArc,
@@ -948,6 +951,32 @@ export class KernelEngine {
           const arcId = entityIdMap.get(c.arc);
           if (lineId !== undefined && arcId !== undefined) {
             sketch.addConstraint(tangent(lineId, arcId, "end", "start"));
+          }
+          break;
+        }
+        case "equalRadius": {
+          const [a, b] = c.arcs ?? [];
+          const e1 = entityIdMap.get(a);
+          const e2 = entityIdMap.get(b);
+          if (e1 !== undefined && e2 !== undefined) {
+            sketch.addConstraint(equalRadius(e1, e2));
+          }
+          break;
+        }
+        case "concentric": {
+          const [a, b] = c.arcs ?? [];
+          const e1 = entityIdMap.get(a);
+          const e2 = entityIdMap.get(b);
+          if (e1 !== undefined && e2 !== undefined) {
+            sketch.addConstraint(concentric(e1, e2));
+          }
+          break;
+        }
+        case "midpoint": {
+          const pid = pointIdMap.get(c.point);
+          const lineId = entityIdMap.get(c.line);
+          if (pid !== undefined && lineId !== undefined) {
+            sketch.addConstraint(midpoint(pid, lineId));
           }
           break;
         }

--- a/packages/app/src/editor/lib/reference-geometry.ts
+++ b/packages/app/src/editor/lib/reference-geometry.ts
@@ -1,0 +1,267 @@
+/**
+ * Reference geometry helpers for planes and axes.
+ *
+ * These are lightweight math utilities used by reference geometry tools
+ * to compute plane/axis previews and feature definitions from selections.
+ */
+
+export type Vec3 = [number, number, number];
+
+export interface PlaneBasis {
+  origin: Vec3;
+  normal: Vec3;
+  xDir: Vec3;
+  yDir: Vec3;
+}
+
+export interface AxisLine {
+  origin: Vec3;
+  direction: Vec3;
+}
+
+export interface MeshData {
+  positions: Float32Array;
+  normals: Float32Array;
+  indices: Uint32Array;
+  faceMap?: Uint32Array;
+  edges?: Float32Array;
+  edgeMap?: Uint32Array;
+}
+
+const EPS = 1e-8;
+
+export function add(a: Vec3, b: Vec3): Vec3 {
+  return [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+}
+
+export function sub(a: Vec3, b: Vec3): Vec3 {
+  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+}
+
+export function mul(v: Vec3, s: number): Vec3 {
+  return [v[0] * s, v[1] * s, v[2] * s];
+}
+
+export function dot(a: Vec3, b: Vec3): number {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+export function cross(a: Vec3, b: Vec3): Vec3 {
+  return [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]];
+}
+
+export function length(v: Vec3): number {
+  return Math.sqrt(dot(v, v));
+}
+
+export function normalize(v: Vec3): Vec3 {
+  const len = length(v);
+  if (len < EPS) return [0, 0, 0];
+  return [v[0] / len, v[1] / len, v[2] / len];
+}
+
+export function computeOrthonormalBasis(normal: Vec3): { xDir: Vec3; yDir: Vec3 } {
+  const n = normalize(normal);
+  const candidate: Vec3 = Math.abs(n[2]) > 0.9999 ? [1, 0, 0] : [0, 0, 1];
+  const xDir = normalize(cross(n, candidate));
+  const yDir = normalize(cross(n, xDir));
+  return { xDir, yDir };
+}
+
+export function rotateVectorAroundAxis(vec: Vec3, axisDir: Vec3, angleRad: number): Vec3 {
+  const k = normalize(axisDir);
+  const cos = Math.cos(angleRad);
+  const sin = Math.sin(angleRad);
+  const term1 = mul(vec, cos);
+  const term2 = mul(cross(k, vec), sin);
+  const term3 = mul(k, dot(k, vec) * (1 - cos));
+  return add(add(term1, term2), term3);
+}
+
+export function rotatePointAroundAxis(
+  point: Vec3,
+  axisOrigin: Vec3,
+  axisDir: Vec3,
+  angleRad: number
+): Vec3 {
+  const relative = sub(point, axisOrigin);
+  const rotated = rotateVectorAroundAxis(relative, axisDir, angleRad);
+  return add(axisOrigin, rotated);
+}
+
+export function computePlaneFromPoints(p1: Vec3, p2: Vec3, p3: Vec3): PlaneBasis | null {
+  const v1 = sub(p2, p1);
+  const v2 = sub(p3, p1);
+  const normal = cross(v1, v2);
+  if (length(normal) < EPS) return null;
+  const xDir = normalize(v1);
+  const yDir = normalize(cross(normal, xDir));
+  return { origin: p1, normal: normalize(normal), xDir, yDir };
+}
+
+export function computeMidplane(a: PlaneBasis, b: PlaneBasis): PlaneBasis | null {
+  let n1 = normalize(a.normal);
+  let n2 = normalize(b.normal);
+  if (dot(n1, n2) < 0) {
+    n2 = mul(n2, -1);
+  }
+  if (length(cross(n1, n2)) > EPS) return null;
+  const distance = dot(sub(b.origin, a.origin), n1);
+  const origin = add(a.origin, mul(n1, distance * 0.5));
+  const xDir = length(a.xDir) > EPS ? normalize(a.xDir) : computeOrthonormalBasis(n1).xDir;
+  const yDir = normalize(cross(n1, xDir));
+  return { origin, normal: n1, xDir, yDir };
+}
+
+export function computeAnglePlane(base: PlaneBasis, axis: AxisLine, angleDeg: number): PlaneBasis {
+  const angleRad = (angleDeg * Math.PI) / 180;
+  const normal = rotateVectorAroundAxis(base.normal, axis.direction, angleRad);
+  const xDir = rotateVectorAroundAxis(base.xDir, axis.direction, angleRad);
+  const origin = rotatePointAroundAxis(base.origin, axis.origin, axis.direction, angleRad);
+  const yDir = normalize(cross(normal, xDir));
+  return { origin, normal: normalize(normal), xDir: normalize(xDir), yDir };
+}
+
+export function computePlaneFromFaceMesh(mesh: MeshData, faceIndex: number): PlaneBasis | null {
+  if (!mesh.faceMap) return null;
+  const positions = mesh.positions;
+  const normals = mesh.normals;
+
+  let count = 0;
+  let centroid: Vec3 = [0, 0, 0];
+  let normalSum: Vec3 = [0, 0, 0];
+
+  for (let i = 0; i < mesh.faceMap.length; i++) {
+    if (mesh.faceMap[i] !== faceIndex) continue;
+
+    const i0 = mesh.indices[i * 3];
+    const i1 = mesh.indices[i * 3 + 1];
+    const i2 = mesh.indices[i * 3 + 2];
+
+    for (const idx of [i0, i1, i2]) {
+      const px = positions[idx * 3];
+      const py = positions[idx * 3 + 1];
+      const pz = positions[idx * 3 + 2];
+      centroid = add(centroid, [px, py, pz]);
+      const nx = normals[idx * 3];
+      const ny = normals[idx * 3 + 1];
+      const nz = normals[idx * 3 + 2];
+      normalSum = add(normalSum, [nx, ny, nz]);
+      count += 1;
+    }
+  }
+
+  if (count === 0) return null;
+  centroid = mul(centroid, 1 / count);
+  const normal = normalize(normalSum);
+  const basis = computeOrthonormalBasis(normal);
+  return { origin: centroid, normal, xDir: basis.xDir, yDir: basis.yDir };
+}
+
+export function computeAxisFromEdgeMesh(mesh: MeshData, edgeIndex: number): AxisLine | null {
+  if (!mesh.edges || !mesh.edgeMap) return null;
+
+  let sumDir: Vec3 = [0, 0, 0];
+  let originSum: Vec3 = [0, 0, 0];
+  let count = 0;
+
+  for (let i = 0; i < mesh.edgeMap.length; i++) {
+    if (mesh.edgeMap[i] !== edgeIndex) continue;
+    const x1 = mesh.edges[i * 6 + 0];
+    const y1 = mesh.edges[i * 6 + 1];
+    const z1 = mesh.edges[i * 6 + 2];
+    const x2 = mesh.edges[i * 6 + 3];
+    const y2 = mesh.edges[i * 6 + 4];
+    const z2 = mesh.edges[i * 6 + 5];
+
+    const v = sub([x2, y2, z2], [x1, y1, z1]);
+    const vLen = length(v);
+    if (vLen < EPS) continue;
+
+    let dir = normalize(v);
+    if (dot(sumDir, dir) < 0) {
+      dir = mul(dir, -1);
+    }
+    sumDir = add(sumDir, dir);
+
+    const mid = mul(add([x1, y1, z1], [x2, y2, z2]), 0.5);
+    originSum = add(originSum, mid);
+    count += 1;
+  }
+
+  if (count === 0) return null;
+  const direction = normalize(sumDir);
+  const origin = mul(originSum, 1 / count);
+  return { origin, direction };
+}
+
+export function computeAxisFromTwoPoints(p1: Vec3, p2: Vec3): AxisLine | null {
+  const dir = sub(p2, p1);
+  if (length(dir) < EPS) return null;
+  return { origin: p1, direction: normalize(dir) };
+}
+
+export function computeAxisFromTwoPlanes(a: PlaneBasis, b: PlaneBasis): AxisLine | null {
+  const n1 = normalize(a.normal);
+  const n2 = normalize(b.normal);
+  const direction = cross(n1, n2);
+  if (length(direction) < EPS) return null;
+
+  // Solve for a point on the intersection line using plane equations.
+  const d1 = dot(n1, a.origin);
+  const d2 = dot(n2, b.origin);
+
+  const abs = direction.map((v) => Math.abs(v));
+  let origin: Vec3 = [0, 0, 0];
+
+  if (abs[0] >= abs[1] && abs[0] >= abs[2]) {
+    // x = 0, solve for y,z
+    const det = n1[1] * n2[2] - n1[2] * n2[1];
+    if (Math.abs(det) < EPS) return null;
+    const y = (d1 * n2[2] - d2 * n1[2]) / det;
+    const z = (d2 * n1[1] - d1 * n2[1]) / det;
+    origin = [0, y, z];
+  } else if (abs[1] >= abs[2]) {
+    // y = 0, solve for x,z
+    const det = n1[0] * n2[2] - n1[2] * n2[0];
+    if (Math.abs(det) < EPS) return null;
+    const x = (d1 * n2[2] - d2 * n1[2]) / det;
+    const z = (d2 * n1[0] - d1 * n2[0]) / det;
+    origin = [x, 0, z];
+  } else {
+    // z = 0, solve for x,y
+    const det = n1[0] * n2[1] - n1[1] * n2[0];
+    if (Math.abs(det) < EPS) return null;
+    const x = (d1 * n2[1] - d2 * n1[1]) / det;
+    const y = (d2 * n1[0] - d1 * n2[0]) / det;
+    origin = [x, y, 0];
+  }
+
+  return { origin, direction: normalize(direction) };
+}
+
+export function parsePointRef(ref: string): Vec3 | null {
+  if (!ref.startsWith("point:")) return null;
+  const raw = ref.slice("point:".length);
+  const parts = raw.split(",").map((v) => Number(v.trim()));
+  if (parts.length !== 3 || parts.some((v) => Number.isNaN(v))) return null;
+  return [parts[0], parts[1], parts[2]];
+}
+
+export function parseFaceRef(ref: string): { featureId: string; faceIndex: number } | null {
+  if (!ref.startsWith("face:")) return null;
+  const parts = ref.split(":");
+  if (parts.length !== 3) return null;
+  const faceIndex = Number(parts[2]);
+  if (Number.isNaN(faceIndex)) return null;
+  return { featureId: parts[1], faceIndex };
+}
+
+export function parseEdgeRef(ref: string): { featureId: string; edgeIndex: number } | null {
+  if (!ref.startsWith("edge:")) return null;
+  const parts = ref.split(":");
+  if (parts.length !== 3) return null;
+  const edgeIndex = Number(parts[2]);
+  if (Number.isNaN(edgeIndex)) return null;
+  return { featureId: parts[1], edgeIndex };
+}

--- a/packages/app/src/editor/types/featureSchemas.ts
+++ b/packages/app/src/editor/types/featureSchemas.ts
@@ -108,6 +108,59 @@ export const planeFormSchema = z.object({
 export type PlaneFormData = z.infer<typeof planeFormSchema>;
 
 // ============================================================================
+// Reference Plane Tool Schema (Phase 28)
+// ============================================================================
+
+export const planeToolModeSchema = z.enum(["auto", "offset", "midplane", "angle", "threePoint"]);
+
+export const planeToolFormSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  mode: planeToolModeSchema,
+  ref1: z.string().optional(),
+  ref2: z.string().optional(),
+  ref3: z.string().optional(),
+  offset: z.number(),
+  angle: z.number(),
+  flipNormal: z.boolean(),
+  width: z.number().min(1),
+  height: z.number().min(1),
+});
+
+export type PlaneToolFormData = z.infer<typeof planeToolFormSchema>;
+
+export const defaultPlaneToolFormData: PlaneToolFormData = {
+  name: "Plane",
+  mode: "auto",
+  offset: 0,
+  angle: 0,
+  flipNormal: false,
+  width: 100,
+  height: 100,
+};
+
+// ============================================================================
+// Reference Axis Tool Schema (Phase 28)
+// ============================================================================
+
+export const axisToolModeSchema = z.enum(["auto", "linear", "twoPoints", "twoPlanes"]);
+
+export const axisToolFormSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  mode: axisToolModeSchema,
+  ref1: z.string().optional(),
+  ref2: z.string().optional(),
+  length: z.number().min(1),
+});
+
+export type AxisToolFormData = z.infer<typeof axisToolFormSchema>;
+
+export const defaultAxisToolFormData: AxisToolFormData = {
+  name: "Axis",
+  mode: "auto",
+  length: 100,
+};
+
+// ============================================================================
 // Boolean Feature Schema (Phase 17)
 // ============================================================================
 

--- a/packages/app/src/editor/worker/kernel.worker.ts
+++ b/packages/app/src/editor/worker/kernel.worker.ts
@@ -35,6 +35,9 @@ import {
   perpendicular,
   equalLength,
   tangent,
+  equalRadius,
+  concentric,
+  midpoint,
   symmetric,
   pointOnLine,
   pointOnArc,
@@ -676,6 +679,32 @@ function interpretSketch(
         const arcId = entityIdMap.get(c.arc);
         if (lineId !== undefined && arcId !== undefined) {
           sketch.addConstraint(tangent(lineId, arcId, "end", "start"));
+        }
+        break;
+      }
+      case "equalRadius": {
+        const [a, b] = c.arcs ?? [];
+        const e1 = entityIdMap.get(a);
+        const e2 = entityIdMap.get(b);
+        if (e1 !== undefined && e2 !== undefined) {
+          sketch.addConstraint(equalRadius(e1, e2));
+        }
+        break;
+      }
+      case "concentric": {
+        const [a, b] = c.arcs ?? [];
+        const e1 = entityIdMap.get(a);
+        const e2 = entityIdMap.get(b);
+        if (e1 !== undefined && e2 !== undefined) {
+          sketch.addConstraint(concentric(e1, e2));
+        }
+        break;
+      }
+      case "midpoint": {
+        const pid = pointIdMap.get(c.point);
+        const lineId = entityIdMap.get(c.line);
+        if (pid !== undefined && lineId !== undefined) {
+          sketch.addConstraint(midpoint(pid, lineId));
         }
         break;
       }

--- a/packages/app/tests/unit/editor/document/sketch-data.test.ts
+++ b/packages/app/tests/unit/editor/document/sketch-data.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Sketch data helper tests
+ */
+
+import { describe, it, expect } from "vitest";
+import * as Y from "yjs";
+
+import { createFeatureMap, createSketchDataMap } from "../../../../src/editor/document/yjs";
+import {
+  addConstraintToSketch,
+  getSketchData,
+  setSketchData,
+  type NewSketchConstraint,
+} from "../../../../src/editor/document/feature-helpers/sketch-data";
+
+describe("sketch-data helpers", () => {
+  const createSketchMap = () => {
+    const doc = new Y.Doc();
+    const root = doc.getMap("root");
+    const sketch = createFeatureMap();
+    root.set("sketch", sketch);
+    sketch.set("data", createSketchDataMap());
+    return sketch as Y.Map<unknown>;
+  };
+
+  it("stores arcs for equalRadius constraints", () => {
+    const sketch = createSketchMap();
+    const constraint: NewSketchConstraint = {
+      type: "equalRadius",
+      arcs: ["arc-a", "arc-b"],
+    };
+
+    const constraintId = addConstraintToSketch(sketch, constraint);
+    const data = getSketchData(sketch);
+    const stored = data.constraintsById[constraintId];
+
+    expect(stored).toBeDefined();
+    expect(stored.type).toBe("equalRadius");
+    expect(stored.arcs).toEqual(["arc-a", "arc-b"]);
+  });
+
+  it("preserves circle entities when setting sketch data", () => {
+    const sketch = createSketchMap();
+    setSketchData(sketch, {
+      points: [{ id: "center", x: 0, y: 0 }],
+      entities: [
+        {
+          id: "circle-1",
+          type: "circle",
+          center: "center",
+          radius: 5,
+          construction: true,
+        },
+      ],
+      constraints: [],
+    });
+
+    const data = getSketchData(sketch);
+    const circle = data.entitiesById["circle-1"];
+
+    expect(circle).toBeDefined();
+    expect(circle.type).toBe("circle");
+    expect(circle.center).toBe("center");
+    expect(circle.radius).toBe(5);
+    expect(circle.construction).toBe(true);
+  });
+});

--- a/packages/app/tests/unit/editor/viewer/inference.test.ts
+++ b/packages/app/tests/unit/editor/viewer/inference.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Inference line helpers tests
+ */
+
+import { describe, it, expect } from "vitest";
+import { computeHVInferenceLines } from "../../../../src/editor/components/viewer/viewer-utils";
+
+describe("computeHVInferenceLines", () => {
+  it("returns a vertical inference line when aligned by x", () => {
+    const points = [{ x: 10, y: 0 }];
+    const cursor = { x: 11, y: 5 };
+    const lines = computeHVInferenceLines(points, cursor, 2);
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0].kind).toBe("vertical");
+    expect(lines[0].start).toEqual({ x: 10, y: 0 });
+    expect(lines[0].end).toEqual({ x: 10, y: 5 });
+  });
+
+  it("returns a horizontal inference line when aligned by y", () => {
+    const points = [{ x: 3, y: 12 }];
+    const cursor = { x: 7, y: 11 };
+    const lines = computeHVInferenceLines(points, cursor, 2);
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0].kind).toBe("horizontal");
+    expect(lines[0].start).toEqual({ x: 3, y: 12 });
+    expect(lines[0].end).toEqual({ x: 7, y: 12 });
+  });
+
+  it("returns both lines when aligned by x and y", () => {
+    const points = [
+      { x: 10, y: 2 },
+      { x: 4, y: 6 },
+    ];
+    const cursor = { x: 9, y: 7 };
+    const lines = computeHVInferenceLines(points, cursor, 2);
+
+    expect(lines).toHaveLength(2);
+    const kinds = lines.map((line) => line.kind).sort();
+    expect(kinds).toEqual(["horizontal", "vertical"]);
+  });
+
+  it("prefers the closest aligned point", () => {
+    const points = [
+      { x: 9, y: 0 },
+      { x: 12, y: 1 },
+    ];
+    const cursor = { x: 10, y: 4 };
+    const lines = computeHVInferenceLines(points, cursor, 3);
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0].kind).toBe("vertical");
+    expect(lines[0].start.x).toBe(9);
+  });
+});

--- a/packages/app/tests/unit/editor/viewer/inference.test.ts
+++ b/packages/app/tests/unit/editor/viewer/inference.test.ts
@@ -46,7 +46,7 @@ describe("computeHVInferenceLines", () => {
       { x: 9, y: 0 },
       { x: 12, y: 1 },
     ];
-    const cursor = { x: 10, y: 4 };
+    const cursor = { x: 10, y: 10 };
     const lines = computeHVInferenceLines(points, cursor, 3);
 
     expect(lines).toHaveLength(1);

--- a/packages/core/tests/model/planes.test.ts
+++ b/packages/core/tests/model/planes.test.ts
@@ -12,6 +12,9 @@ import {
   FRONT_PLANE,
   createDatumPlaneFromNormal,
   createOffsetPlane,
+  createMidplane,
+  create3PointPlane,
+  createAnglePlane,
   getPlaneOrigin,
   getPlaneNormal,
   getPlaneXDir,
@@ -149,5 +152,44 @@ describe("worldToPlane", () => {
     const back = worldToPlane(XY_PLANE, world);
     expect(back[0]).toBeCloseTo(x);
     expect(back[1]).toBeCloseTo(y);
+  });
+});
+
+describe("createMidplane", () => {
+  it("creates a plane between two parallel planes", () => {
+    const plane1 = createOffsetPlane(XY_PLANE, 0);
+    const plane2 = createOffsetPlane(XY_PLANE, 10);
+    const mid = createMidplane(plane1, plane2);
+
+    expect(getPlaneOrigin(mid)[2]).toBeCloseTo(5);
+    expect(getPlaneNormal(mid)).toEqual([0, 0, 1]);
+  });
+
+  it("throws for non-parallel planes", () => {
+    expect(() => createMidplane(XY_PLANE, YZ_PLANE)).toThrow(/parallel/i);
+  });
+});
+
+describe("create3PointPlane", () => {
+  it("creates plane through three points", () => {
+    const plane = create3PointPlane(vec3(0, 0, 0), vec3(10, 0, 0), vec3(0, 10, 0));
+    const normal = getPlaneNormal(plane);
+    expect(normal[2]).toBeCloseTo(1);
+  });
+
+  it("throws for collinear points", () => {
+    expect(() =>
+      create3PointPlane(vec3(0, 0, 0), vec3(5, 0, 0), vec3(10, 0, 0))
+    ).toThrow(/collinear/i);
+  });
+});
+
+describe("createAnglePlane", () => {
+  it("rotates plane around axis by angle", () => {
+    const axis = { origin: vec3(0, 0, 0), direction: vec3(1, 0, 0) };
+    const plane = createAnglePlane(XY_PLANE, axis, 90);
+    const normal = getPlaneNormal(plane);
+    expect(normal[1]).toBeCloseTo(1);
+    expect(normal[2]).toBeCloseTo(0, 6);
   });
 });


### PR DESCRIPTION
Implements Phase 28 reference geometry and sketch tooling, including new plane/axis creation methods, sketch modification tools, and advanced constraints.

This PR integrates the planned UX from `@docs/CAD-UX-SPEC.md` and the technical implementation from `@plan/28-reference-geometry-sketch-tooling.md`. It introduces UI for creating planes (offset, midplane, 3-point, angle) and axes (linear, two points, two planes), along with sketch modification tools (trim, extend, offset, mirror, fillet, chamfer) and new sketch constraints (equal radius, concentric, midpoint, improved tangent).

---
<a href="https://cursor.com/background-agent?bcId=bc-4082f322-f479-4f63-8295-59225f85da16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4082f322-f479-4f63-8295-59225f85da16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

